### PR TITLE
Avoid conflicts with obtrusive libraries and polyfills

### DIFF
--- a/implementation.js
+++ b/implementation.js
@@ -2,6 +2,7 @@
 
 var ES = require('es-abstract/es7');
 
+var defineProperty = Object.defineProperty;
 var getDescriptor = Object.getOwnPropertyDescriptor;
 var getOwnNames = Object.getOwnPropertyNames;
 var getSymbols = Object.getOwnPropertySymbols;
@@ -19,7 +20,9 @@ module.exports = function getOwnPropertyDescriptors(value) {
 
 	var O = ES.ToObject(value);
 	return reduce(getAll(O), function (acc, key) {
-		acc[key] = getDescriptor(O, key);
+	        var desc = getDescriptor(O, key);
+	        if (key in acc) defineProperty(acc, key, desc);
+		else acc[key] = desc;
 		return acc;
 	}, {});
 };


### PR DESCRIPTION
Accidentally I've seen the [core-js implementation](https://github.com/zloirock/core-js/blob/master/modules/es7.object.get-own-property-descriptors.js) and it took a second to realize if someone adds some accessor to the `Object.prototype` the current polyfill will be fragile enough to possible interfere with those accessors.

Using `defineProperty` instead ensures the object will have the property configured as own one.

This is specially crucial when it comes to polyfill `Symbols`