### PR TITLE
Avoid conflicts with possible Object.prototype accessors

### DIFF
--- a/implementation.js
+++ b/implementation.js
@@ -2,6 +2,7 @@
 
 var ES = require('es-abstract/es7');
 
+var defineProperty = Object.defineProperty;
 var getDescriptor = Object.getOwnPropertyDescriptor;
 var getOwnNames = Object.getOwnPropertyNames;
 var getSymbols = Object.getOwnPropertySymbols;
@@ -19,7 +20,21 @@ module.exports = function getOwnPropertyDescriptors(value) {
 
 	var O = ES.ToObject(value);
 	return reduce(getAll(O), function (acc, key) {
-		acc[key] = getDescriptor(O, key);
+	        var desc = getDescriptor(O, key);
+	        if (key in acc) {
+	                defineProperty(
+	                        acc,
+	                        key,
+	                        {
+	                                configurable: true,
+	                                enumerable: true,
+	                                writable: true,
+	                                value: desc
+	                        }
+	                );
+	        } else {
+		        acc[key] = getDescriptor(O, key);
+	        }
 		return acc;
 	}, {});
 };


### PR DESCRIPTION
Coming from PR #1 this is the spec compliant version of the method.

In case there is some obtrusive polyfill (`Symbol`) or framework around (Polymer `WeakMap` sham) that uses accessors on the `Object.prototype` the current version would possibly suffer conflicts when such property, or symbol, would be assigned to the accumulator object.

The current check avoids, only when necessary in order to preserve performance,  every possible conflict with these cases.