### PR TITLE
Added TypeScript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,3 @@
+export default function getOwnPropertyDescriptors<T>(
+  o: T
+): { [P in keyof T]: TypedPropertyDescriptor<T[P]> } & { [x: string]: PropertyDescriptor };


### PR DESCRIPTION
I added the TypeScript definition for getOwnPropetyDescriptors. It doesn't include definition for the polyfill. It might be better to just add a comment to readme on how to modify the Object definition for getOwnPropertyDescriptors.